### PR TITLE
Fixes blank filedir.

### DIFF
--- a/byond/map/__init__.py
+++ b/byond/map/__init__.py
@@ -981,7 +981,7 @@ class Map:
         
         if pic is not None:
             # Saev
-            filedir = os.path.dirname(filename)
+            filedir = os.path.dirname(os.path.abspath(filename))
             if not os.path.isdir(filedir):
                 os.makedirs(filedir)
             print(' -> {} ({}x{}) - {} objects'.format(filename, pic.size[0], pic.size[1], pastes))


### PR DESCRIPTION
Fixes #9, an exception caused by the filedir coming back blank. (At least on windows.)
